### PR TITLE
Eliminate Moose::Autobox in tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension {{$dist->name}}
 
 {{$NEXT}}
+    - Eliminate use of Moose::Autobox in tests [GH#5 - kentnl++]
 
 2.000005  2013-05-18
     - Allow tests to run in parallel [GH#3 - kentnl++]

--- a/t/deprecated.t
+++ b/t/deprecated.t
@@ -3,7 +3,6 @@ use warnings;
 use Test::More 0.96 tests => 2;
 use Test::Output;
 use Test::DZil;
-use Moose::Autobox;
 
 my $tzil;
 
@@ -22,7 +21,7 @@ stderr_like(
 );
 $tzil->build;
 
-my @xtests = map $_->name =~ m{^xt/} ? $_->name : (), $tzil->files->flatten;
+my @xtests = map $_->name =~ m{^xt/} ? $_->name : (), @{ $tzil->files };
 ok(
     (grep { $_ eq 'xt/release/minimum-version.t' } @xtests),
     'minimum-version.t exists'

--- a/t/everything.t
+++ b/t/everything.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 use Test::More 0.96 tests => 2;
 use Test::DZil;
-use Moose::Autobox;
 
 subtest 'explicit version' => sub {
     plan tests => 2;
@@ -19,9 +18,9 @@ subtest 'explicit version' => sub {
     );
     $tzil->build;
 
-    my ($test) = map { $_->name eq 'xt/release/minimum-version.t' ? $_ : () } $tzil->files->flatten;
+    my ($test) = map { $_->name eq 'xt/release/minimum-version.t' ? $_ : () } @{ $tzil->files };
     ok $test, 'minimum-version.t exists'
-        or diag explain [ map { $_->name } $tzil->files->flatten ];
+        or diag explain [ map { $_->name } @{ $tzil->files } ];
 
     like $test->content => qr{\Q5.10.1\E}, 'max_target_perl used in test';
 };
@@ -41,9 +40,9 @@ subtest 'version from metayml' => sub {
     );
     $tzil->build;
 
-    my ($test) = map { $_->name eq 'xt/release/minimum-version.t' ? $_ : () } $tzil->files->flatten;
+    my ($test) = map { $_->name eq 'xt/release/minimum-version.t' ? $_ : () } @{ $tzil->files };
     ok $test, 'minimum-version.t exists'
-        or diag explain [ map { $_->name } $tzil->files->flatten ];
+        or diag explain [ map { $_->name } @{ $tzil->files } ];
 
     like $test->content => qr{metayml}, 'metayml used in test';
 };


### PR DESCRIPTION
This eliminates an unnecessarily fragile path that currently impedes dzil
work on bleadperls.

Same logic and caveats as https://github.com/doherty/Dist-Zilla-Plugin-Test-CPAN-Changes/pull/5 